### PR TITLE
Added warning if regexp contains '.*'

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,13 @@ No additional logic (e.g. counting repeated occurrences within a time interval f
 
     [rules.sshd-invalid-user]
     source = ["file", "/var/log/auth.log"]
-    regexp = "Invalid user.*%host%"
+    regexp = "Invalid user.*?%host%"
     action = ["ban", "24h"]
 ```
+
+**Please note**: Try to avoid using ```.?``` in regexp. This might have unwanted behaviour. Use ```.*?``` instead. 
+
+Example: In the regexp ```Invalid user.*%host%```, the ```.*``` expression will match ```Invalid user derda from 9```, which cuts off the first number of the IP address. By using ```.*?```, this problem will not occur.
 
 ## Example systemd service file
 

--- a/gerberos.toml
+++ b/gerberos.toml
@@ -7,7 +7,7 @@
     # "%host%" must appear exactly once in regexp.
     # It will be replaced with a subexpression named
     # "host" matching IPv4 and IPv6 addresses.
-    regexp = "%host%.*40(0|8) 0 \"-\" \"-\""
+    regexp = "%host%.*?40(0|8) 0 \"-\" \"-\""
     # Available actions are
     # - ["ban", "<value parsable by time.ParseDuration>"]
     # - ["log"]
@@ -15,5 +15,5 @@
 
     [rules.sshd-invalid-user]
     source = ["file", "/var/log/auth.log"]
-    regexp = "Invalid user.*%host%"
+    regexp = "Invalid user.*?%host%"
     action = ["ban", "24h"]

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func execute(n string, args ...string) (string, int, error) {
 	log.Printf("executing: %s", cmd)
 	b, err := cmd.CombinedOutput()
 	if err != nil {
-		if eerr := err.(*exec.ExitError); eerr != nil {
+		if eerr, ok := err.(*exec.ExitError); ok && eerr != nil {
 			return string(b), eerr.ExitCode(), eerr
 		} else {
 			return "", -1, err

--- a/rules.go
+++ b/rules.go
@@ -16,8 +16,9 @@ const (
 )
 
 var (
-	ipMagicRegexp = regexp.MustCompile(ipMagicText)
-	ipRegexpText  = `(?P<host>(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}|(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)::((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?))`
+	ipMagicRegexp     = regexp.MustCompile(ipMagicText)
+	ipRegexpText      = `(?P<host>(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}|(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)::((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?))`
+	dotstarTestRegexp = regexp.MustCompile(`\.\*[^\?]`)
 )
 
 type rule struct {
@@ -51,6 +52,10 @@ func (r *rule) initializeSource() error {
 func (r *rule) initializeRegexp() error {
 	if strings.Contains(r.Regexp, "(?P<host>") {
 		return errors.New(`regexp must not contain a subexpression named "host" ("(?P<host>")`)
+	}
+
+	if dotstarTestRegexp.MatchString(r.Regexp) {
+		log.Printf("Warning: Regexp of rule '%s' contains '.*' - this might have unwanted behaviour. Maybe use '.*?' instead. See documentation for more information.", r.name)
 	}
 
 	if len(ipMagicRegexp.FindAllStringIndex(r.Regexp, -1)) != 1 {


### PR DESCRIPTION
This can have unwanted behaviour since '.*' is greedy and might consume
parts of the IP address.