### PR TITLE
Added easier regexp

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -24,11 +24,11 @@ func (a *banAction) initialize(r *rule) error {
 		return errors.New("missing duration parameter")
 	}
 
-	if d, err := time.ParseDuration(r.Action[1]); err != nil {
+	d, err := time.ParseDuration(r.Action[1])
+	if err != nil {
 		return fmt.Errorf("failed to parse duration parameter: %s", err)
-	} else {
-		a.duration = d
 	}
+	a.duration = d
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -36,11 +36,11 @@ func execute(n string, args ...string) (string, int, error) {
 	}
 	b, err := cmd.CombinedOutput()
 	if err != nil {
-		if eerr, ok := err.(*exec.ExitError); ok && eerr != nil {
+		eerr, ok := err.(*exec.ExitError)
+		if ok && eerr != nil {
 			return string(b), eerr.ExitCode(), eerr
-		} else {
-			return "", -1, err
 		}
+		return "", -1, err
 	}
 	return string(b), 0, nil
 }
@@ -146,9 +146,8 @@ func isInstanceAlreadyRunning() (bool, error) {
 		if p == n {
 			if oc {
 				return true, nil
-			} else {
-				oc = true
 			}
+			oc = true
 		}
 	}
 

--- a/matches_test.go
+++ b/matches_test.go
@@ -42,6 +42,25 @@ func TestMatches(t *testing.T) {
 		t.Errorf(`expected host "192.168.1.1", got "%s"`, m.host)
 	}
 
+	ml("invalid 4.1", "300.300.300.300", "%host%", false)
+	ml("invalid 4.2", "100.100.100", "%host%", false)
+	ml("invalid 4.3", "100..100.100.100", "%host%", false)
+	ml("invalid 4.4", "start 1000.100.100.100 end", "start %host% end", false)
+	ml("invalid 4.5", "start 100.100.100.100.100.100 end", "start %host% end", false)
+	ml("invalid 6.1", "affe:affe", "%host%", false)
+	ml("invalid 6.2", "1a:1a", "%host%", false)
+	ml("invalid 6.3", "start 3ab9:1ea0:c269:5aad:b716:c28d:237d:4d8f:3ab9:1ea0:c269:5aad:b716:c28d:237d:4d8f end", "start %host% end", false)
+
+	ml("valid 4.1", "147.144.139.204", "%host%", true)
+	ml("valid 4.2", "49.236.157.198", "%host%", true)
+	ml("valid 4.3", "1.1.1.1", "%host%", true)
+	ml("valid 4.4", "255.255.255.254", "%host%", true)
+	ml("valid 6.1", "a0ca:14f:80b2::77e6:f471:361e", "%host%", true)
+	ml("valid 6.2", "35bb:6be1:abae:de1:adbd:aecd:2813:a993", "%host%", true)
+	ml("valid 6.3", "3ab9:1ea0:c269:5aad:b716:c28d:237d:4d8f", "%host%", true)
+	ml("valid 6.4", "affe::affe", "%host%", true)
+	ml("valid 6.5", "1a::1a", "%host%", true)
+
 	em("valid 2.1", "0.0.0.0", false)
 	em("valid 2.2", "11.0.0.0", false)
 	em("valid 2.3", "129.56.0.0", false)

--- a/rules.go
+++ b/rules.go
@@ -18,7 +18,7 @@ const (
 
 var (
 	ipMagicRegexp     = regexp.MustCompile(ipMagicText)
-	ipRegexpText      = `(?P<host>(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}|(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)::((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?))`
+	ipRegexpText      = `(?P<host>(\d?\d?\d\.){3}\d?\d?\d|([0-9A-Fa-f]{0,4}::?){1,6}[0-9A-Fa-f]{0,4}::?[0-9A-Fa-f]{0,4})`
 	dotstarTestRegexp = regexp.MustCompile(`\.\*[^\?]`)
 )
 

--- a/rules.go
+++ b/rules.go
@@ -107,11 +107,11 @@ func (r *rule) initializeRegexp() error {
 			return fmt.Errorf(`"%s" must appear exactly once in regexp`, ipMagicText)
 		}
 
-		if re, err := regexp.Compile(strings.Replace(s, ipMagicText, ipRegexpText, 1)); err != nil {
+		re, err := regexp.Compile(strings.Replace(s, ipMagicText, ipRegexpText, 1))
+		if err != nil {
 			return err
-		} else {
-			r.regexp = append(r.regexp, re)
 		}
+		r.regexp = append(r.regexp, re)
 	}
 
 	return nil


### PR DESCRIPTION
The old regexp was really hard to understand. This version is way easier, but at the same time catches more invalid IP addresses. However, this shouldn't be a problem since net.ParseIP filters out bad results.